### PR TITLE
Upgrade to XP 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,39 +3,32 @@ plugins {
     id 'jacoco'
     id 'maven-publish'
     id 'com.enonic.defaults' version '2.1.6'
-    id 'com.enonic.xp.app' version '3.6.2'
+    id 'com.enonic.xp.app'
     id "com.github.node-gradle.node" version '7.1.0'
 }
 
-app {
-    name = "${appName}"
-    displayName = "${appDisplayName}"
-    vendorName = "${vendorName}"
-    vendorUrl = "${vendorUrl}"
-    systemVersion = "${xpVersion}"
-}
-
 dependencies {
-    compileOnly "com.enonic.xp:core-api:${xpVersion}"
-    compileOnly "com.enonic.xp:portal-api:${xpVersion}"
-    compileOnly "com.enonic.xp:web-api:${xpVersion}"
+    compileOnly xplibs.api.core
+    compileOnly xplibs.api.portal
+    compileOnly xplibs.api.web
 
-    include 'org.apache.commons:commons-csv:1.14.1'
+    include libs.commons.csv
 
-    include "com.enonic.xp:lib-content:${xpVersion}"
-    include "com.enonic.xp:lib-portal:${xpVersion}"
-    include "com.enonic.xp:lib-io:${xpVersion}"
-    include "com.enonic.xp:lib-vhost:${xpVersion}"
-    include "com.enonic.xp:lib-event:${xpVersion}"
-    include "com.enonic.xp:lib-auth:${xpVersion}"
-    include "com.enonic.xp:lib-context:${xpVersion}"
-    include "com.enonic.xp:lib-cluster:${xpVersion}"
-    include 'com.enonic.lib:lib-thymeleaf:2.1.1'
-    include 'com.enonic.lib:lib-license:3.1.0'
+    include xplibs.content
+    include xplibs.portal
+    include xplibs.io
+    include xplibs.vhost
+    include xplibs.event
+    include xplibs.auth
+    include xplibs.context
+    include xplibs.cluster
+    include libs.lib.thymeleaf
+    include libs.lib.license
 
     testImplementation 'org.mockito:mockito-core:5.21.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.21.0'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.11.4'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation "com.enonic.xp:testing:${xpVersion}"
 }
 
@@ -43,6 +36,7 @@ repositories {
     mavenLocal()
     mavenCentral()
     xp.enonicRepo()
+    xp.enonicRepo('dev')
 }
 
 jacocoTestReport {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,11 +3,8 @@ projectName = rewrite
 version=1.2.2-SNAPSHOT
 
 # XP App values
-appDisplayName = Rewrite
 appName = com.enonic.app.rewrite
-vendorName = Enonic
-vendorUrl = https://enonic.com
-xpVersion = 7.6.0
+xpVersion = 8.0.0-B4
 
 # Settings for publishing to a Maven repo
 group = com.enonic.app

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,9 @@
+[versions]
+lib-thymeleaf = "3.0.0-SNAPSHOT"
+lib-license = "3.1.0"
+commons-csv = "1.14.1"
+
+[libraries]
+lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "lib-thymeleaf" }
+lib-license = { module = "com.enonic.lib:lib-license", version.ref = "lib-license" }
+commons-csv = { module = "org.apache.commons:commons-csv", version.ref = "commons-csv" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+    id 'com.enonic.xp.settings' version '4.0.0-B1'
+}
+
 rootProject.name = projectName

--- a/src/main/java/com/enonic/app/rewrite/RewriteService.java
+++ b/src/main/java/com/enonic/app/rewrite/RewriteService.java
@@ -3,7 +3,7 @@ package com.enonic.app.rewrite;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentMap;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import com.enonic.app.rewrite.domain.RewriteContextKey;
 import com.enonic.app.rewrite.domain.RewriteMapping;

--- a/src/main/java/com/enonic/app/rewrite/RewriteServiceImpl.java
+++ b/src/main/java/com/enonic/app/rewrite/RewriteServiceImpl.java
@@ -15,7 +15,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;

--- a/src/main/java/com/enonic/app/rewrite/context/ContextResolver.java
+++ b/src/main/java/com/enonic/app/rewrite/context/ContextResolver.java
@@ -1,6 +1,6 @@
 package com.enonic.app.rewrite.context;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/enonic/app/rewrite/engine/RewriteEngine.java
+++ b/src/main/java/com/enonic/app/rewrite/engine/RewriteEngine.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/com/enonic/app/rewrite/filter/RequestWrapper.java
+++ b/src/main/java/com/enonic/app/rewrite/filter/RequestWrapper.java
@@ -1,7 +1,7 @@
 package com.enonic.app.rewrite.filter;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 
 class RequestWrapper
     extends HttpServletRequestWrapper

--- a/src/main/java/com/enonic/app/rewrite/filter/RewriteFilter.java
+++ b/src/main/java/com/enonic/app/rewrite/filter/RewriteFilter.java
@@ -1,10 +1,10 @@
 package com.enonic.app.rewrite.filter;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.annotation.WebFilter;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.annotation.WebFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;

--- a/src/main/java/com/enonic/app/rewrite/provider/repo/RewriteMappingRepoInitializer.java
+++ b/src/main/java/com/enonic/app/rewrite/provider/repo/RewriteMappingRepoInitializer.java
@@ -71,7 +71,7 @@ public class RewriteMappingRepoInitializer
     @Override
     protected boolean isInitialized()
     {
-        return createAdminContext().callWith( () -> this.repositoryService.isInitialized( REPO_ID ) );
+        return createAdminContext().callWith( () -> this.repositoryService.get( REPO_ID ) != null );
     }
 
     private void doCreateRepo()

--- a/src/main/java/com/enonic/app/rewrite/provider/repo/RewriteMappingSerializer.java
+++ b/src/main/java/com/enonic/app/rewrite/provider/repo/RewriteMappingSerializer.java
@@ -65,7 +65,7 @@ public class RewriteMappingSerializer
 
         if ( rewriteMapping.getRewriteRules() != null )
         {
-            data.addSets( RULES_KEY, createRules( rewriteMapping.getRewriteRules() ) );
+            data.addSets( RULES_KEY, createRules( propertyTree, rewriteMapping.getRewriteRules() ) );
         }
 
         data.setString( CONTEXT_KEY, rewriteMapping.getContextKey().toString() );
@@ -77,12 +77,12 @@ public class RewriteMappingSerializer
         return toBeEdited -> toBeEdited.data = toCreateNodeData( rewriteMapping );
     }
 
-    private static PropertySet[] createRules( final RewriteRules rewriteRules )
+    private static PropertySet[] createRules( final PropertyTree propertyTree, final RewriteRules rewriteRules )
     {
         final List<PropertySet> setList = new ArrayList<>();
 
         rewriteRules.getRuleList().forEach( rule -> {
-            final PropertySet ruleData = new PropertySet();
+            final PropertySet ruleData = propertyTree.newSet();
             ruleData.addString( RULE_IDENTIFIER, rule.getRuleId() );
             ruleData.addString( RULE_FROM_KEY, rule.getFrom() );
             ruleData.addString( RULE_TARGET_KEY, rule.getTarget().path() );

--- a/src/main/java/com/enonic/app/rewrite/provider/repo/RewriteRepoMappingProvider.java
+++ b/src/main/java/com/enonic/app/rewrite/provider/repo/RewriteRepoMappingProvider.java
@@ -20,6 +20,7 @@ import com.enonic.xp.context.ContextAccessor;
 import com.enonic.xp.context.ContextBuilder;
 import com.enonic.xp.data.PropertyTree;
 import com.enonic.xp.node.CreateNodeParams;
+import com.enonic.xp.node.DeleteNodeParams;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeIds;
 import com.enonic.xp.node.NodePath;
@@ -33,7 +34,7 @@ import com.enonic.xp.security.auth.AuthenticationInfo;
 public class RewriteRepoMappingProvider
     implements RewriteMappingProvider
 {
-    public final static NodePath MAPPING_ROOT_NODE = NodePath.create( "/vhosts" ).build();
+    public final static NodePath MAPPING_ROOT_NODE = new NodePath( "/vhosts" );
 
     private final NodeService nodeService;
 
@@ -205,7 +206,9 @@ public class RewriteRepoMappingProvider
 
     private NodeIds doDelete( final RewriteContextKey rewriteContextKey )
     {
-        final NodeIds nodeIds = this.nodeService.deleteByPath( createContextNodePath( rewriteContextKey ) );
+        final NodeIds nodeIds = this.nodeService.delete( DeleteNodeParams.create().
+            nodePath( createContextNodePath( rewriteContextKey ) ).
+            build() ).getNodeIds();
 
         System.out.println( "Deleting nodes with id" + nodeIds );
 
@@ -254,7 +257,7 @@ public class RewriteRepoMappingProvider
 
     private NodePath createContextNodePath( final RewriteContextKey contextKey )
     {
-        return NodePath.create( MAPPING_ROOT_NODE, RewriteContextName.from( contextKey ).getName() ).build();
+        return NodePath.create( MAPPING_ROOT_NODE ).addElement( RewriteContextName.from( contextKey ).getName() ).build();
     }
 
     private Context setRepoContext()

--- a/src/main/java/com/enonic/app/rewrite/requesttester/RewriteTesterRequest.java
+++ b/src/main/java/com/enonic/app/rewrite/requesttester/RewriteTesterRequest.java
@@ -14,20 +14,21 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import javax.servlet.AsyncContext;
-import javax.servlet.DispatcherType;
-import javax.servlet.RequestDispatcher;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.ServletInputStream;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-import javax.servlet.http.HttpUpgradeHandler;
-import javax.servlet.http.Part;
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletConnection;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpUpgradeHandler;
+import jakarta.servlet.http.Part;
 
 class RewriteTesterRequest
     implements HttpServletRequest
@@ -212,12 +213,6 @@ class RewriteTesterRequest
 
     @Override
     public boolean isRequestedSessionIdFromURL()
-    {
-        return false;
-    }
-
-    @Override
-    public boolean isRequestedSessionIdFromUrl()
     {
         return false;
     }
@@ -418,12 +413,6 @@ class RewriteTesterRequest
     }
 
     @Override
-    public String getRealPath( final String s )
-    {
-        return null;
-    }
-
-    @Override
     public int getRemotePort()
     {
         return 0;
@@ -487,6 +476,24 @@ class RewriteTesterRequest
 
     @Override
     public DispatcherType getDispatcherType()
+    {
+        return null;
+    }
+
+    @Override
+    public String getRequestId()
+    {
+        return null;
+    }
+
+    @Override
+    public String getProtocolRequestId()
+    {
+        return null;
+    }
+
+    @Override
+    public ServletConnection getServletConnection()
     {
         return null;
     }

--- a/src/main/resources/admin/tools/rewrite-manager/rewrite-manager.xml
+++ b/src/main/resources/admin/tools/rewrite-manager/rewrite-manager.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0"?>
-<tool xmlns="urn:enonic:xp:model:1.0">
-  <display-name>Rewrite Manager</display-name>
-  <description>Rewrite-configuration and management</description>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</tool>

--- a/src/main/resources/admin/tools/rewrite-manager/rewrite-manager.yaml
+++ b/src/main/resources/admin/tools/rewrite-manager/rewrite-manager.yaml
@@ -1,0 +1,6 @@
+kind: "AdminTool"
+title: "Rewrite Manager"
+description: "Rewrite-configuration and management"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/application.xml
+++ b/src/main/resources/application.xml
@@ -1,3 +1,0 @@
-<application>
-  <description>Manage and execute URL redirection</description>
-</application>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,5 @@
+kind: "Application"
+title: "Rewrite"
+description: "Manage and execute URL redirection"
+vendorName: "Enonic"
+vendorUrl: "https://enonic.com"

--- a/src/main/resources/services/check-context-status/check-context-status.xml
+++ b/src/main/resources/services/check-context-status/check-context-status.xml
@@ -1,6 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/check-context-status/check-context-status.yaml
+++ b/src/main/resources/services/check-context-status/check-context-status.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/license/license.xml
+++ b/src/main/resources/services/license/license.xml
@@ -1,6 +1,0 @@
-<service>
-    <allow>
-        <principal>role:system.admin</principal>
-        <principal>role:com.enonic.app.rewrite.admin</principal>
-    </allow>
-</service>

--- a/src/main/resources/services/license/license.yaml
+++ b/src/main/resources/services/license/license.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/request-tester/request-tester.xml
+++ b/src/main/resources/services/request-tester/request-tester.xml
@@ -1,6 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/request-tester/request-tester.yaml
+++ b/src/main/resources/services/request-tester/request-tester.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/tool-context-action-create-repo-context/tool-context-action-create-repo-context.xml
+++ b/src/main/resources/services/tool-context-action-create-repo-context/tool-context-action-create-repo-context.xml
@@ -1,5 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tool-context-action-create-repo-context/tool-context-action-create-repo-context.yaml
+++ b/src/main/resources/services/tool-context-action-create-repo-context/tool-context-action-create-repo-context.yaml
@@ -1,0 +1,3 @@
+kind: "Service"
+allow:
+  - "role:system.admin"

--- a/src/main/resources/services/tool-context-action-create/tool-context-action-create.xml
+++ b/src/main/resources/services/tool-context-action-create/tool-context-action-create.xml
@@ -1,6 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tool-context-action-create/tool-context-action-create.yaml
+++ b/src/main/resources/services/tool-context-action-create/tool-context-action-create.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/tool-context-action-delete-repo-context/tool-context-action-delete-repo-context.xml
+++ b/src/main/resources/services/tool-context-action-delete-repo-context/tool-context-action-delete-repo-context.xml
@@ -1,6 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tool-context-action-delete-repo-context/tool-context-action-delete-repo-context.yaml
+++ b/src/main/resources/services/tool-context-action-delete-repo-context/tool-context-action-delete-repo-context.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/tool-context-data-context/tool-context-data-context.xml
+++ b/src/main/resources/services/tool-context-data-context/tool-context-data-context.xml
@@ -1,6 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tool-context-data-context/tool-context-data-context.yaml
+++ b/src/main/resources/services/tool-context-data-context/tool-context-data-context.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/tool-context-render/tool-context-render.xml
+++ b/src/main/resources/services/tool-context-render/tool-context-render.xml
@@ -1,6 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tool-context-render/tool-context-render.yaml
+++ b/src/main/resources/services/tool-context-render/tool-context-render.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/tool-rules-action-create/tool-rules-action-create.xml
+++ b/src/main/resources/services/tool-rules-action-create/tool-rules-action-create.xml
@@ -1,6 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tool-rules-action-create/tool-rules-action-create.yaml
+++ b/src/main/resources/services/tool-rules-action-create/tool-rules-action-create.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/tool-rules-action-delete-rule/tool-rules-action-delete-rule.xml
+++ b/src/main/resources/services/tool-rules-action-delete-rule/tool-rules-action-delete-rule.xml
@@ -1,6 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tool-rules-action-delete-rule/tool-rules-action-delete-rule.yaml
+++ b/src/main/resources/services/tool-rules-action-delete-rule/tool-rules-action-delete-rule.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/tool-rules-action-edit-rule/tool-rules-action-edit-rule.xml
+++ b/src/main/resources/services/tool-rules-action-edit-rule/tool-rules-action-edit-rule.xml
@@ -1,6 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tool-rules-action-edit-rule/tool-rules-action-edit-rule.yaml
+++ b/src/main/resources/services/tool-rules-action-edit-rule/tool-rules-action-edit-rule.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/tool-rules-action-export/tool-rules-action-export.xml
+++ b/src/main/resources/services/tool-rules-action-export/tool-rules-action-export.xml
@@ -1,6 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tool-rules-action-export/tool-rules-action-export.yaml
+++ b/src/main/resources/services/tool-rules-action-export/tool-rules-action-export.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/tool-rules-action-import/tool-rules-action-import.xml
+++ b/src/main/resources/services/tool-rules-action-import/tool-rules-action-import.xml
@@ -1,6 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tool-rules-action-import/tool-rules-action-import.yaml
+++ b/src/main/resources/services/tool-rules-action-import/tool-rules-action-import.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/tool-rules-data-context-selector/tool-rules-data-context-selector.xml
+++ b/src/main/resources/services/tool-rules-data-context-selector/tool-rules-data-context-selector.xml
@@ -1,6 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tool-rules-data-context-selector/tool-rules-data-context-selector.yaml
+++ b/src/main/resources/services/tool-rules-data-context-selector/tool-rules-data-context-selector.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/tool-rules-data-export/tool-rules-data-export.xml
+++ b/src/main/resources/services/tool-rules-data-export/tool-rules-data-export.xml
@@ -1,6 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tool-rules-data-export/tool-rules-data-export.yaml
+++ b/src/main/resources/services/tool-rules-data-export/tool-rules-data-export.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/tool-rules-data-provider-info/tool-rules-data-provider-info.xml
+++ b/src/main/resources/services/tool-rules-data-provider-info/tool-rules-data-provider-info.xml
@@ -1,6 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tool-rules-data-provider-info/tool-rules-data-provider-info.yaml
+++ b/src/main/resources/services/tool-rules-data-provider-info/tool-rules-data-provider-info.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/tool-rules-data-rules/tool-rules-data-rules.xml
+++ b/src/main/resources/services/tool-rules-data-rules/tool-rules-data-rules.xml
@@ -1,6 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tool-rules-data-rules/tool-rules-data-rules.yaml
+++ b/src/main/resources/services/tool-rules-data-rules/tool-rules-data-rules.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/tool-rules-modal-create/tool-rules-modal-create.xml
+++ b/src/main/resources/services/tool-rules-modal-create/tool-rules-modal-create.xml
@@ -1,6 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tool-rules-modal-create/tool-rules-modal-create.yaml
+++ b/src/main/resources/services/tool-rules-modal-create/tool-rules-modal-create.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/tool-rules-modal-edit/tool-rules-modal-edit.xml
+++ b/src/main/resources/services/tool-rules-modal-edit/tool-rules-modal-edit.xml
@@ -1,6 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tool-rules-modal-edit/tool-rules-modal-edit.yaml
+++ b/src/main/resources/services/tool-rules-modal-edit/tool-rules-modal-edit.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/tool-rules-modal-export/tool-rules-modal-export.xml
+++ b/src/main/resources/services/tool-rules-modal-export/tool-rules-modal-export.xml
@@ -1,6 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tool-rules-modal-export/tool-rules-modal-export.yaml
+++ b/src/main/resources/services/tool-rules-modal-export/tool-rules-modal-export.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/tool-rules-modal-import/tool-rules-modal-import.xml
+++ b/src/main/resources/services/tool-rules-modal-import/tool-rules-modal-import.xml
@@ -1,6 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tool-rules-modal-import/tool-rules-modal-import.yaml
+++ b/src/main/resources/services/tool-rules-modal-import/tool-rules-modal-import.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/tool-rules-render/tool-rules-render.xml
+++ b/src/main/resources/services/tool-rules-render/tool-rules-render.xml
@@ -1,6 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tool-rules-render/tool-rules-render.yaml
+++ b/src/main/resources/services/tool-rules-render/tool-rules-render.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/tool-tester-render/tool-tester-render.xml
+++ b/src/main/resources/services/tool-tester-render/tool-tester-render.xml
@@ -1,6 +1,0 @@
-<service>
-  <allow>
-    <principal>role:system.admin</principal>
-    <principal>role:com.enonic.app.rewrite.admin</principal>
-  </allow>
-</service>

--- a/src/main/resources/services/tool-tester-render/tool-tester-render.yaml
+++ b/src/main/resources/services/tool-tester-render/tool-tester-render.yaml
@@ -1,0 +1,4 @@
+kind: "Service"
+allow:
+  - "role:system.admin"
+  - "role:com.enonic.app.rewrite.admin"

--- a/src/test/java/com/enonic/app/rewrite/MockHttpRequest.java
+++ b/src/test/java/com/enonic/app/rewrite/MockHttpRequest.java
@@ -2,7 +2,7 @@ package com.enonic.app.rewrite;
 
 import java.net.URI;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.mockito.Mockito;
 

--- a/src/test/java/com/enonic/app/rewrite/engine/RewriteEngineImplTest.java
+++ b/src/test/java/com/enonic/app/rewrite/engine/RewriteEngineImplTest.java
@@ -2,7 +2,7 @@ package com.enonic.app.rewrite.engine;
 
 import java.util.List;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/enonic/app/rewrite/mapping/RewriteMappingsMapperTest.java
+++ b/src/test/java/com/enonic/app/rewrite/mapping/RewriteMappingsMapperTest.java
@@ -10,7 +10,7 @@ import com.enonic.app.rewrite.domain.RewriteMapping;
 import com.enonic.app.rewrite.domain.RewriteRule;
 import com.enonic.app.rewrite.domain.RewriteRules;
 import com.enonic.app.rewrite.redirect.RedirectType;
-import com.enonic.xp.script.serializer.JsonMapGenerator;
+import com.enonic.xp.testing.serializer.JsonMapGenerator;
 
 class RewriteMappingsMapperTest
 {

--- a/src/test/java/com/enonic/app/rewrite/provider/repo/NodeServiceMock.java
+++ b/src/test/java/com/enonic/app/rewrite/provider/repo/NodeServiceMock.java
@@ -1,28 +1,22 @@
 package com.enonic.app.rewrite.provider.repo;
 
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.io.ByteSource;
 
-import com.enonic.xp.blob.NodeVersionKey;
 import com.enonic.xp.branch.Branch;
 import com.enonic.xp.node.ApplyNodePermissionsParams;
 import com.enonic.xp.node.ApplyNodePermissionsResult;
-import com.enonic.xp.node.AttachedBinaries;
-import com.enonic.xp.node.AttachedBinary;
-import com.enonic.xp.node.BinaryAttachment;
+import com.enonic.xp.node.ApplyVersionAttributesParams;
+import com.enonic.xp.node.Attributes;
+import com.enonic.xp.node.CommitNodeParams;
 import com.enonic.xp.node.CreateNodeParams;
-import com.enonic.xp.node.CreateRootNodeParams;
-import com.enonic.xp.node.DeleteNodeListener;
+import com.enonic.xp.node.DeleteNodeParams;
+import com.enonic.xp.node.DeleteNodeResult;
 import com.enonic.xp.node.DuplicateNodeParams;
+import com.enonic.xp.node.DuplicateNodeResult;
 import com.enonic.xp.node.EditableNode;
-import com.enonic.xp.node.FindNodePathsByQueryResult;
 import com.enonic.xp.node.FindNodesByMultiRepoQueryResult;
 import com.enonic.xp.node.FindNodesByParentParams;
 import com.enonic.xp.node.FindNodesByParentResult;
@@ -30,14 +24,11 @@ import com.enonic.xp.node.FindNodesByQueryResult;
 import com.enonic.xp.node.GetActiveNodeVersionsParams;
 import com.enonic.xp.node.GetActiveNodeVersionsResult;
 import com.enonic.xp.node.GetNodeVersionsParams;
-import com.enonic.xp.node.ImportNodeCommitParams;
+import com.enonic.xp.node.GetNodeVersionsResult;
 import com.enonic.xp.node.ImportNodeParams;
 import com.enonic.xp.node.ImportNodeResult;
-import com.enonic.xp.node.ImportNodeVersionParams;
-import com.enonic.xp.node.LoadNodeParams;
-import com.enonic.xp.node.LoadNodeResult;
-import com.enonic.xp.node.MoveNodeListener;
 import com.enonic.xp.node.MoveNodeParams;
+import com.enonic.xp.node.MoveNodeResult;
 import com.enonic.xp.node.MultiRepoNodeQuery;
 import com.enonic.xp.node.Node;
 import com.enonic.xp.node.NodeCommitEntry;
@@ -59,110 +50,41 @@ import com.enonic.xp.node.NodeVersionId;
 import com.enonic.xp.node.NodeVersionQuery;
 import com.enonic.xp.node.NodeVersionQueryResult;
 import com.enonic.xp.node.Nodes;
-import com.enonic.xp.node.NodesHasChildrenResult;
-import com.enonic.xp.node.PushNodesListener;
+import com.enonic.xp.node.PatchNodeParams;
+import com.enonic.xp.node.PatchNodeResult;
+import com.enonic.xp.node.PushNodeParams;
 import com.enonic.xp.node.PushNodesResult;
 import com.enonic.xp.node.RefreshMode;
-import com.enonic.xp.node.RenameNodeParams;
-import com.enonic.xp.node.ReorderChildNodesParams;
-import com.enonic.xp.node.ReorderChildNodesResult;
 import com.enonic.xp.node.ResolveSyncWorkResult;
-import com.enonic.xp.node.RoutableNodeVersionIds;
-import com.enonic.xp.node.SetNodeChildOrderParams;
-import com.enonic.xp.node.SetNodeStateParams;
-import com.enonic.xp.node.SetNodeStateResult;
+import com.enonic.xp.node.SortNodeParams;
+import com.enonic.xp.node.SortNodeResult;
 import com.enonic.xp.node.SyncWorkResolverParams;
 import com.enonic.xp.node.UpdateNodeParams;
-import com.enonic.xp.security.acl.AccessControlList;
 import com.enonic.xp.util.BinaryReference;
 
 class NodeServiceMock
     implements NodeService
 {
-    private final static Logger LOG = LoggerFactory.getLogger( NodeServiceMock.class );
-
     private final Map<NodeId, Node> nodeIdMap = new HashMap<>();
 
     private final Map<NodePath, Node> nodePathMap = new HashMap<>();
 
     private final MockNodeTree<NodePath> nodeTree = new MockNodeTree<>( NodePath.ROOT );
 
-    private final Map<BinaryReference, ByteSource> blobStore = new HashMap<>();
-
-    public NodeServiceMock()
-    {
-        super();
-    }
-
     @Override
     public Node create( final CreateNodeParams params )
     {
-        return doCreate( params );
-    }
-
-    private Node doCreate( final CreateNodeParams params )
-    {
-        return doCreate( params, null );
-    }
-
-    @Override
-    public void importNodeVersion( final ImportNodeVersionParams params )
-    {
-        throw new UnsupportedOperationException( "Not implemented in mock" );
-    }
-
-    @Override
-    public void importNodeCommit( final ImportNodeCommitParams params )
-    {
-        throw new UnsupportedOperationException( "Not implemented in mock" );
-    }
-
-    @Override
-    public LoadNodeResult loadNode( final LoadNodeParams params )
-    {
-        throw new UnsupportedOperationException( "Not implemented in mock" );
-    }
-
-    @Override
-    public NodeVersionQueryResult findVersions( final NodeVersionQuery nodeVersionQuery )
-    {
-        throw new UnsupportedOperationException( "Not implemented in mock" );
-    }
-
-    @Override
-    public NodeCommitQueryResult findCommits( final NodeCommitQuery nodeCommitQuery )
-    {
-        throw new UnsupportedOperationException( "Not implemented in mock" );
-    }
-
-    private Node doCreate( final CreateNodeParams params, final Instant timestamp )
-    {
-        final Node.Builder builder = Node.create().
+        final Node createdNode = Node.create().
             id( params.getNodeId() != null ? params.getNodeId() : NodeId.from( System.nanoTime() ) ).
             name( NodeName.from( params.getName() ) ).
             parentPath( params.getParent() ).
-            timestamp( timestamp ).
             manualOrderValue( params.getManualOrderValue() ).
             childOrder( params.getChildOrder() ).
-            data( params.getData() );
-
-        final AttachedBinaries.Builder attachmentBuilder = AttachedBinaries.create();
-
-        for ( final BinaryAttachment binaryAttachment : params.getBinaryAttachments() )
-        {
-            final String blobKey = binaryAttachment.getReference().toString();
-            attachmentBuilder.add( new AttachedBinary( binaryAttachment.getReference(), blobKey ) );
-            blobStore.put( binaryAttachment.getReference(), binaryAttachment.getByteSource() );
-        }
-
-        builder.attachedBinaries( attachmentBuilder.build() );
-
-        final Node createdNode = builder.build();
+            data( params.getData() ).
+            build();
 
         nodeIdMap.putIfAbsent( createdNode.id(), createdNode );
-        // LOG.info( "Store id " + createdNode.id() );
         nodePathMap.putIfAbsent( createdNode.path(), createdNode );
-        //LOG.info( "Store path " + createdNode.path() );
 
         final MockNodeTree<NodePath> nodePathTreeNode = this.nodeTree.find( createdNode.parentPath() );
 
@@ -189,84 +111,49 @@ class NodeServiceMock
             return persistedNode;
         }
 
-        final Node.Builder updateNodeBuilder = Node.create( editedNode ).
-            permissions( persistedNode.getPermissions() );
+        final Node updated = Node.create( editedNode ).
+            permissions( persistedNode.getPermissions() ).
+            build();
 
-        return updateNodeBuilder.build();
+        nodeIdMap.put( updated.id(), updated );
+        nodePathMap.put( updated.path(), updated );
+
+        return updated;
     }
 
     @Override
-    public Node rename( final RenameNodeParams params )
+    public DeleteNodeResult delete( final DeleteNodeParams params )
     {
-        throw new UnsupportedOperationException( "Not implemented in mock" );
-    }
+        final NodePath path = params.getNodePath();
+        final NodeId id = params.getNodeId();
 
-    @Override
-    public PushNodesResult push( final NodeIds ids, final Branch target )
-    {
-        throw new UnsupportedOperationException( "Not implemented in mock" );
-    }
+        final Node toBeRemoved;
+        if ( path != null )
+        {
+            toBeRemoved = this.nodePathMap.get( path );
+        }
+        else
+        {
+            toBeRemoved = this.nodeIdMap.get( id );
+        }
 
-    @Override
-    public PushNodesResult push( final NodeIds ids, final Branch target, final PushNodesListener pushListener )
-    {
-        throw new UnsupportedOperationException( "Not implemented in mock" );
-    }
-
-    @Override
-    public NodeIds deleteById( final NodeId id )
-    {
-        return deleteById( id, null );
-    }
-
-    @Override
-    public NodeIds deleteById( final NodeId id, final DeleteNodeListener deleteNodeListener )
-    {
-        final Node toBeRemoved = this.nodeIdMap.get( id );
+        if ( toBeRemoved == null )
+        {
+            return DeleteNodeResult.create().build();
+        }
 
         final MockNodeTree<NodePath> treeNode = nodeTree.find( toBeRemoved.path() );
-        treeNode.getParent().children.remove( treeNode );
+        if ( treeNode != null && treeNode.getParent() != null )
+        {
+            treeNode.getParent().children.remove( treeNode );
+        }
 
         this.nodePathMap.remove( toBeRemoved.path() );
         this.nodeIdMap.remove( toBeRemoved.id() );
 
-        return NodeIds.from( id );
-    }
-
-    @Override
-    public NodeIds deleteByPath( final NodePath path )
-    {
-        final MockNodeTree<NodePath> treeNode = nodeTree.find( path );
-        treeNode.getParent().children.remove( treeNode );
-
-        final Node toBeRemoved = this.nodePathMap.get( path );
-
-        this.nodePathMap.remove( path );
-        this.nodeIdMap.remove( toBeRemoved.id() );
-
-        return NodeIds.from( toBeRemoved.id() );
-    }
-
-    @Override
-    public Node getById( final NodeId id )
-    {
-        return nodeIdMap.get( id );
-    }
-
-    @Override
-    public Node getByIdAndVersionId( final NodeId id, final NodeVersionId versionId )
-    {
-        return null;
-    }
-
-    @Override
-    public Nodes getByIds( final NodeIds ids )
-    {
-        final Nodes.Builder builder = Nodes.create();
-
-        ids.forEach( id -> builder.add( this.nodeIdMap.get( id ) ) );
-
-        return builder.build();
+        return DeleteNodeResult.create().
+            add( new DeleteNodeResult.Result( toBeRemoved.id(), null ) ).
+            build();
     }
 
     @Override
@@ -276,11 +163,66 @@ class NodeServiceMock
     }
 
     @Override
-    public Node getByPathAndVersionId( final NodePath path, final NodeVersionId versionId )
+    public Node getById( final NodeId id )
+    {
+        return nodeIdMap.get( id );
+    }
+
+    @Override
+    public Nodes getByIds( final NodeIds ids )
+    {
+        final Nodes.Builder builder = Nodes.create();
+        ids.forEach( id -> builder.add( this.nodeIdMap.get( id ) ) );
+        return builder.build();
+    }
+
+    @Override
+    public void refresh( final RefreshMode refreshMode )
+    {
+        // no-op
+    }
+
+    @Override
+    public boolean nodeExists( final NodeId nodeId )
+    {
+        return nodeIdMap.containsKey( nodeId );
+    }
+
+    @Override
+    public boolean nodeExists( final NodePath nodePath )
+    {
+        return nodePathMap.containsKey( nodePath );
+    }
+
+    @Override
+    public PatchNodeResult patch( final PatchNodeParams params )
+    {
+        throw new UnsupportedOperationException( "Not implemented in mock" );
+    }
+
+    @Override
+    public MoveNodeResult move( final MoveNodeParams params )
+    {
+        throw new UnsupportedOperationException( "Not implemented in mock" );
+    }
+
+    @Override
+    public PushNodesResult push( final PushNodeParams params )
+    {
+        throw new UnsupportedOperationException( "Not implemented in mock" );
+    }
+
+    @Override
+    public Node getByIdAndVersionId( final NodeId id, final NodeVersionId versionId )
+    {
+        throw new UnsupportedOperationException( "Not implemented in mock" );
+    }
+
+    @Override
+    public NodeVersion getVersion( final NodeId nodeId, final NodeVersionId nodeVersionId )
     {
         return null;
     }
-
 
     @Override
     public Nodes getByPaths( final NodePaths paths )
@@ -289,57 +231,15 @@ class NodeServiceMock
     }
 
     @Override
-    public Node duplicate( final DuplicateNodeParams params )
+    public DuplicateNodeResult duplicate( final DuplicateNodeParams params )
     {
-        return null;
-    }
-
-    @Override
-    public Node move( final NodeId nodeId, final NodePath parentNodePath, final MoveNodeListener moveListener )
-    {
-        return null;
-    }
-
-    @Override
-    public Node move( final MoveNodeParams moveNodeParams )
-    {
-        return null;
+        throw new UnsupportedOperationException( "Not implemented in mock" );
     }
 
     @Override
     public FindNodesByParentResult findByParent( final FindNodesByParentParams params )
     {
-        final MockNodeTree<NodePath> parentNode = this.nodeTree.find( params.getParentPath() );
-
-        if ( parentNode == null )
-        {
-            throw new IllegalArgumentException( "Parent with path: " + params.getParentPath() + " not found" );
-        }
-
-        final FindNodesByParentResult.Builder resultBuilder = FindNodesByParentResult.create();
-
-        final Nodes.Builder nodesBuilder = Nodes.create();
-        getNodes( parentNode, nodesBuilder, params.isRecursive() );
-        final Nodes nodes = nodesBuilder.build();
-
-        return resultBuilder.hits( nodes.getSize() ).
-            nodeIds( NodeIds.from( nodes.getSet().stream().
-                map( Node::id ).
-                collect( Collectors.toList() ) ) ).
-            totalHits( nodes.getSize() ).
-            build();
-    }
-
-    private void getNodes( MockNodeTree<NodePath> parentNode, Nodes.Builder nodesBuilder, final boolean recursive )
-    {
-        for ( final MockNodeTree<NodePath> treeNode : parentNode.children )
-        {
-            nodesBuilder.add( nodePathMap.get( treeNode.data ) );
-            if ( recursive )
-            {
-                getNodes( treeNode, nodesBuilder, recursive );
-            }
-        }
+        throw new UnsupportedOperationException( "Not implemented in mock" );
     }
 
     @Override
@@ -349,7 +249,7 @@ class NodeServiceMock
     }
 
     @Override
-    public FindNodePathsByQueryResult findNodePathsByQuery( final NodeQuery nodeQuery )
+    public FindNodesByMultiRepoQueryResult findByQuery( final MultiRepoNodeQuery nodeQuery )
     {
         throw new UnsupportedOperationException( "Not implemented in mock" );
     }
@@ -367,7 +267,19 @@ class NodeServiceMock
     }
 
     @Override
-    public NodeVersionQueryResult findVersions( final GetNodeVersionsParams params )
+    public GetNodeVersionsResult getVersions( final GetNodeVersionsParams params )
+    {
+        throw new UnsupportedOperationException( "Not implemented in mock" );
+    }
+
+    @Override
+    public NodeVersionQueryResult findVersions( final NodeVersionQuery nodeVersionQuery )
+    {
+        throw new UnsupportedOperationException( "Not implemented in mock" );
+    }
+
+    @Override
+    public NodeCommitQueryResult findCommits( final NodeCommitQuery nodeCommitQuery )
     {
         throw new UnsupportedOperationException( "Not implemented in mock" );
     }
@@ -379,31 +291,13 @@ class NodeServiceMock
     }
 
     @Override
-    public Node setChildOrder( final SetNodeChildOrderParams params )
+    public SortNodeResult sort( final SortNodeParams params )
     {
         throw new UnsupportedOperationException( "Not implemented in mock" );
     }
 
     @Override
-    public ReorderChildNodesResult reorderChildren( final ReorderChildNodesParams params )
-    {
-        throw new UnsupportedOperationException( "Not implemented in mock" );
-    }
-
-    @Override
-    public NodeVersion getByNodeVersionKey( final NodeVersionKey nodeVersionKey )
-    {
-        throw new UnsupportedOperationException( "Not implemented in mock" );
-    }
-
-    @Override
-    public ByteSource getBinary( final NodeId nodeId, final BinaryReference reference )
-    {
-        return this.blobStore.get( reference );
-    }
-
-    @Override
-    public String getBinaryKey( final NodeId nodeId, final BinaryReference reference )
+    public ResolveSyncWorkResult resolveSyncWork( final SyncWorkResolverParams params )
     {
         throw new UnsupportedOperationException( "Not implemented in mock" );
     }
@@ -415,70 +309,7 @@ class NodeServiceMock
     }
 
     @Override
-    public ResolveSyncWorkResult resolveSyncWork( final SyncWorkResolverParams params )
-    {
-        throw new UnsupportedOperationException( "Not implemented in mock" );
-    }
-
-    @Override
-    public Node createRootNode( final CreateRootNodeParams params )
-    {
-        final Node rootNode = Node.createRoot().build();
-        nodeIdMap.putIfAbsent( rootNode.id(), rootNode );
-        nodePathMap.putIfAbsent( rootNode.path(), rootNode );
-        return rootNode;
-    }
-
-    @Override
-    public SetNodeStateResult setNodeState( final SetNodeStateParams params )
-    {
-        throw new UnsupportedOperationException( "Not implemented in mock" );
-    }
-
-    @Override
-    public NodeVersionId setActiveVersion( final NodeId nodeId, final NodeVersionId nodeVersionId )
-    {
-        throw new UnsupportedOperationException( "Not implemented in mock" );
-    }
-
-    @Override
-    public void refresh( final RefreshMode refreshMode )
-    {
-        // Dont do anything
-    }
-
-    @Override
-    public Node getRoot()
-    {
-        throw new UnsupportedOperationException( "Not implemented in mock" );
-    }
-
-    @Override
-    public boolean nodeExists( final NodeId nodeId )
-    {
-        throw new UnsupportedOperationException( "Not implemented in mock" );
-    }
-
-    @Override
-    public boolean nodeExists( final NodePath nodePath )
-    {
-        throw new UnsupportedOperationException( "Not implemented in mock" );
-    }
-
-    @Override
-    public Nodes move( final NodeIds nodeIds, final NodePath parentNodePath, MoveNodeListener moveListener )
-    {
-        throw new UnsupportedOperationException( "Not implemented in mock" );
-    }
-
-    @Override
-    public NodesHasChildrenResult hasChildren( final Nodes nodes )
-    {
-        throw new UnsupportedOperationException( "Not implemented in mock" );
-    }
-
-    @Override
-    public boolean hasChildren( final Node node )
+    public ByteSource getBinary( final NodeId nodeId, final BinaryReference reference )
     {
         throw new UnsupportedOperationException( "Not implemented in mock" );
     }
@@ -492,59 +323,11 @@ class NodeServiceMock
     @Override
     public ImportNodeResult importNode( final ImportNodeParams params )
     {
-        final Node importNode = params.getNode();
-        final boolean preExist = this.nodePathMap.get( importNode.path() ) != null;
-
-        final Node createdNode;
-        if ( importNode.isRoot() )
-        {
-            createdNode = createRootNode( null );
-        }
-        else
-        {
-            createdNode = doCreate( CreateNodeParams.create().
-                setBinaryAttachments( params.getBinaryAttachments() ).
-                childOrder( importNode.getChildOrder() ).
-                data( importNode.data() ).
-                indexConfigDocument( importNode.getIndexConfigDocument() ).
-                insertManualStrategy( params.getInsertManualStrategy() ).
-                manualOrderValue( importNode.getManualOrderValue() ).
-                name( importNode.name().toString() ).
-                parent( importNode.parentPath() ).
-                setNodeId( importNode.id() ).
-                permissions( importNode.getPermissions() ).
-                build(), importNode.getTimestamp() );
-        }
-
-        return ImportNodeResult.create().node( createdNode ).preExisting( preExist ).build();
-    }
-
-    @Override
-    public Node setRootPermissions( final AccessControlList accessControlList, final boolean inheritPermissions )
-    {
         throw new UnsupportedOperationException( "Not implemented in mock" );
     }
 
     @Override
-    public boolean hasUnpublishedChildren( final NodeId parent, final Branch target )
-    {
-        throw new UnsupportedOperationException( "Not implemented in mock" );
-    }
-
-    @Override
-    public FindNodesByMultiRepoQueryResult findByQuery( final MultiRepoNodeQuery nodeQuery )
-    {
-        throw new UnsupportedOperationException( "Not implemented in mock" );
-    }
-
-    @Override
-    public boolean deleteVersion( final NodeId nodeId, final NodeVersionId nodeVersionId )
-    {
-        throw new UnsupportedOperationException( "Not implemented in mock" );
-    }
-
-    @Override
-    public NodeCommitEntry commit( final NodeCommitEntry nodeCommitEntry, final RoutableNodeVersionIds routableNodeVersionIds )
+    public NodeCommitEntry commit( final CommitNodeParams params )
     {
         throw new UnsupportedOperationException( "Not implemented in mock" );
     }
@@ -557,6 +340,18 @@ class NodeServiceMock
 
     @Override
     public NodeCommitEntry getCommit( final NodeCommitId nodeCommitId )
+    {
+        throw new UnsupportedOperationException( "Not implemented in mock" );
+    }
+
+    @Override
+    public boolean hasUnpublishedChildren( final NodeId parent, final Branch target )
+    {
+        throw new UnsupportedOperationException( "Not implemented in mock" );
+    }
+
+    @Override
+    public Attributes applyVersionAttributes( final ApplyVersionAttributesParams params )
     {
         throw new UnsupportedOperationException( "Not implemented in mock" );
     }

--- a/src/test/java/com/enonic/app/rewrite/provider/repo/RewriteRepoMappingProviderTest.java
+++ b/src/test/java/com/enonic/app/rewrite/provider/repo/RewriteRepoMappingProviderTest.java
@@ -39,7 +39,7 @@ class RewriteRepoMappingProviderTest
         this.repositoryService = Mockito.mock( RepositoryService.class );
 
         Mockito.when( this.indexService.isMaster() ).thenReturn( true );
-        Mockito.when( this.repositoryService.isInitialized( REPO_ID ) ).thenReturn( true );
+        Mockito.when( this.repositoryService.get( REPO_ID ) ).thenReturn( Mockito.mock() );
 
         this.nodeService.create( CreateNodeParams.create().
             parent( MAPPING_ROOT_NODE.getParentPath() ).
@@ -67,7 +67,7 @@ class RewriteRepoMappingProviderTest
 
         service.store( rewriteMapping );
 
-        final Node storedNode = this.nodeService.getByPath( NodePath.create( MAPPING_ROOT_NODE, "myVHost" ).build() );
+        final Node storedNode = this.nodeService.getByPath( NodePath.create( MAPPING_ROOT_NODE ).addElement( "myVHost" ).build() );
         assertNotNull( storedNode );
         final RewriteMapping storedRewriteMapping = RewriteMappingSerializer.fromNode( storedNode );
 


### PR DESCRIPTION
## Summary

Upgrade `app-rewrite` from XP 7 to XP 8 following the `xp-app-upgrader` skill.

- **xpVersion:** `7.6.0` → `8.0.0-B4`
- **Gradle wrapper:** `8.5` → `9.4.1`
- **Settings plugin:** added `com.enonic.xp.settings` `4.0.0-B1` in `settings.gradle`; dropped the `com.enonic.xp.app` version pin and the `app{}` block in `build.gradle`.
- **Descriptors:** ran `xp8migrator -e overwrite` to convert `application.xml`, `admin/tools/rewrite-manager/`, and all `services/*/` XML descriptors to YAML, and deleted the originals.
- **Dependencies:** switched `com.enonic.xp:lib-*` deps to `xplibs.*` catalog aliases; moved third-party libs (`lib-thymeleaf` bumped to `3.0.0-SNAPSHOT` for XP 8, `lib-license`, `commons-csv`) into a new `gradle/libs.versions.toml`. Added `xp.enonicRepo('dev')` for the Thymeleaf snapshot, and `testRuntimeOnly 'org.junit.platform:junit-platform-launcher'` for the JUnit 5 tests.
- **Java code:** migrated `javax.servlet` → `jakarta.servlet` (incl. implementing the new `ServletConnection`/`getRequestId`/`getProtocolRequestId` methods on the test request, and dropping removed `isRequestedSessionIdFromUrl`/`getRealPath`); replaced `RepositoryService.isInitialized(REPO_ID)` with `get(REPO_ID) != null`; switched `NodeService.deleteByPath` to `delete(DeleteNodeParams)`; replaced `new PropertySet()` with `propertyTree.newSet()`; updated `NodePath.create(parent, "name")` to `create(parent).addElement("name")` (and `NodePath.create("/x").build()` to `new NodePath("/x")`).
- **Tests:** moved `JsonMapGenerator` import to `com.enonic.xp.testing.serializer`; rewrote the in-memory `NodeServiceMock` against the XP 8 `NodeService` interface (only the few methods the tests exercise are implemented; the rest throw `UnsupportedOperationException`).

`./gradlew clean build` is green locally. **Runtime verification was not performed** — the runner sandbox is ephemeral and a deploy step was out of scope. CI on this PR is the next step.

## Test plan

- [ ] CI `./gradlew build` passes on the new branch
- [ ] Sanity-deploy on a local XP 8 server (out of scope for this run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)