### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Gradle Project settings
 projectName = rewrite
-version=1.2.2-SNAPSHOT
+version=2.0.0-SNAPSHOT
 
 # XP App values
 appName = com.enonic.app.rewrite


### PR DESCRIPTION
## Summary

- Bumps `version` in `gradle.properties` from `1.2.2-SNAPSHOT` to `2.0.0-SNAPSHOT` (master is now the XP 8 line).
- Adds a `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `1.x`, so release tooling treats both as release branches.

The XP 7 maintenance line continues on `1.x`, branched from the post-`v1.2.1` "Updated to next SNAPSHOT version" commit (`e17ddcf`) so its `gradle.properties` remains at `1.2.2-SNAPSHOT`.

Companion PR on `1.x` adds the same `releaseBranch:` block there (the action reads the workflow file from the branch being built).

Reference: app-booster's master/1.x split.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, a build on master classifies as a release branch
- [ ] After companion `1.x` PR merges, a build on `1.x` classifies as a release branch