### PR TITLE
Add release-branch CI config for 1.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds a `releaseBranch:` block to `.github/workflows/enonic-gradle.yml` listing both `master` and `1.x`.
- Required so pushes to `1.x` are recognized as release-branch builds — the release tooling reads `releaseBranch:` from the workflow file on the branch being built.

This is the `1.x` companion to the master XP 8 split (#1127). No version bump or other changes on this branch — `1.x` continues the XP 7 maintenance line at `1.2.2-SNAPSHOT` (post-`v1.2.1` SNAPSHOT commit).

Reference: app-booster's master/1.x split.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, the next push to `1.x` classifies as a release branch in the build-and-publish action