### PR TITLE
Bump lib-license to 4.0.0-SNAPSHOT #1130

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 lib-thymeleaf = "3.0.0-SNAPSHOT"
-lib-license = "3.1.0"
+lib-license = "4.0.0-SNAPSHOT"
 commons-csv = "1.14.1"
 
 [libraries]


### PR DESCRIPTION
Closes #1130.

## What changed
- `gradle/libs.versions.toml`: `lib-license` `3.1.0` → `4.0.0-SNAPSHOT`.

## Why
During the XP 8 E2E verification of `app-rewrite` (issue #1130), the app deployed cleanly but its bundle could not obtain the `LicenseManager` OSGi service. `lib-license` 3.1.0's `LicenseManagerImpl` static initializer calls `NodePath.create(NodePath, String)`, which was removed from XP 8's public API:

```
java.lang.NoSuchMethodError: 'com.enonic.xp.node.NodePath$Builder com.enonic.xp.node.NodePath.create(com.enonic.xp.node.NodePath, java.lang.String)'
    at com.enonic.lib.license.LicenseManagerImpl.<clinit> ...
```

The `RewriteAppActivator` then logged `Could not get service from ref [com.enonic.lib.license.LicenseManager]` and `main.js` crashed at first call to `licenseManagerLib.isCurrentLicenseValid()`.

`lib-license` `4.0.0-SNAPSHOT` (on `repo.enonic.com/dev`) is rebuilt against the XP 8 `NodePath` API. `build.gradle` already declares `xp.enonicRepo('dev')`, so no other change is needed.

## Verification
Built against `xpVersion=8.0.0-B4` (as declared in `gradle.properties`) and re-deployed into a fresh `xp-distro` install:

- Bundle reaches ACTIVE — `Started application com.enonic.app.rewrite bundle 117`.
- `RewriteService initialized` — OSGi DS wires the service successfully.
- `Creating rewrite-repository` + `com.enonic.app.rewrite successfully initialized` — repo init works.
- Zero `ERROR` lines attributable to the bundle in `server.log`.
- Admin tool route registered: `GET /admin/com.enonic.app.rewrite/rewrite-manager` returns 401 with the XP login page (the route exists; would be a 404 "Admin application not found" otherwise).