### PR TITLE
Migrate to lib-asset #1132

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     include xplibs.cluster
     include libs.lib.thymeleaf
     include libs.lib.license
+    include libs.lib.asset
 
     testImplementation 'org.mockito:mockito-core:5.23.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.23.0'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,11 @@
 [versions]
 lib-thymeleaf = "3.0.0-SNAPSHOT"
 lib-license = "4.0.0-SNAPSHOT"
+lib-asset = "2.0.0-SNAPSHOT"
 commons-csv = "1.14.1"
 
 [libraries]
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "lib-thymeleaf" }
 lib-license = { module = "com.enonic.lib:lib-license", version.ref = "lib-license" }
+lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "lib-asset" }
 commons-csv = { module = "org.apache.commons:commons-csv", version.ref = "commons-csv" }

--- a/src/main/resources/admin/tools/rewrite-manager/rewrite-manager.js
+++ b/src/main/resources/admin/tools/rewrite-manager/rewrite-manager.js
@@ -1,5 +1,6 @@
 const thymeleaf = require('/lib/thymeleaf');
 const portal = require('/lib/xp/portal');
+const assetLib = require('/lib/enonic/asset');
 const libVHost = require('/lib/xp/vhost');
 const licenseManager = require("/lib/license-manager");
 
@@ -25,7 +26,7 @@ exports.get = function (req) {
     }
 
     const model = {
-        assetsUrl: portal.assetUrl({path: ""}),
+        assetsUrl: assetLib.assetUrl({path: ""}),
         svcUrl: portal.serviceUrl({service: 'Z'}).slice(0, -1),
         error: !licenseValid || !!errorMessage,
         errorMessage,

--- a/src/main/resources/admin/tools/rewrite-manager/rewrite-manager.yaml
+++ b/src/main/resources/admin/tools/rewrite-manager/rewrite-manager.yaml
@@ -1,6 +1,8 @@
 kind: "AdminTool"
 title: "Rewrite Manager"
 description: "Rewrite-configuration and management"
+apis:
+  - "asset"
 allow:
   - "role:system.admin"
   - "role:com.enonic.app.rewrite.admin"

--- a/src/main/resources/services/tool-context-render/tool-context-render.js
+++ b/src/main/resources/services/tool-context-render/tool-context-render.js
@@ -1,12 +1,13 @@
 let thymeleaf = require('/lib/thymeleaf');
 let portal = require('/lib/xp/portal');
+let assetLib = require('/lib/enonic/asset');
 
 exports.get = function (req) {
 
     let view = resolve('tool-context-render.html');
 
     let model = {
-        assetsUrl: portal.assetUrl({path: ""}),
+        assetsUrl: assetLib.assetUrl({path: ""}),
         svcUrl: portal.serviceUrl({service: 'Z'}).slice(0, -1),
         toolKey: "tool-context"
     };

--- a/src/main/resources/services/tool-rules-render/tool-rules-render.js
+++ b/src/main/resources/services/tool-rules-render/tool-rules-render.js
@@ -1,12 +1,13 @@
 let thymeleaf = require('/lib/thymeleaf');
 let portal = require('/lib/xp/portal');
+let assetLib = require('/lib/enonic/asset');
 
 exports.get = function (req) {
 
     let view = resolve('tool-rules-render.html');
 
     let model = {
-        assetsUrl: portal.assetUrl({path: ""}),
+        assetsUrl: assetLib.assetUrl({path: ""}),
         svcUrl: portal.serviceUrl({service: 'Z'}).slice(0, -1),
         toolKey: "tool-rules"
     };

--- a/src/main/resources/services/tool-tester-render/tool-tester-render.js
+++ b/src/main/resources/services/tool-tester-render/tool-tester-render.js
@@ -1,5 +1,6 @@
 let thymeleaf = require('/lib/thymeleaf');
 let portal = require('/lib/xp/portal');
+let assetLib = require('/lib/enonic/asset');
 let rewriteDao = require('/lib/rewrite-dao');
 
 exports.get = function (req) {
@@ -19,7 +20,7 @@ exports.get = function (req) {
     });
 
     let model = {
-        assetsUrl: portal.assetUrl({path: ""}),
+        assetsUrl: assetLib.assetUrl({path: ""}),
         svcUrl: portal.serviceUrl({service: 'Z'}).slice(0, -1),
         toolKey: "tool-tester",
         rewriteContexts: contexts


### PR DESCRIPTION
Closes #1132

`portal.assetUrl` is `@deprecated` in lib-portal (`Use libAsset or libStatic instead. This function will be removed in future versions.`). All four call sites in this app live in the admin-tool context, so lib-asset is the correct target (lib-static isn't needed — no admin extensions, ID providers, or Universal APIs in this app).

## Changes

- `build.gradle` + `gradle/libs.versions.toml` — added `com.enonic.lib:lib-asset:2.0.0-SNAPSHOT`.
- `src/main/resources/admin/tools/rewrite-manager/rewrite-manager.yaml` — added `apis: ["asset"]` so the bundled asset API is mounted under the admin tool.
- `src/main/resources/admin/tools/rewrite-manager/rewrite-manager.js`
- `src/main/resources/services/tool-tester-render/tool-tester-render.js`
- `src/main/resources/services/tool-rules-render/tool-rules-render.js`
- `src/main/resources/services/tool-context-render/tool-context-render.js`

In each `.js` file, `portal.assetUrl({path: ""})` is replaced with `assetLib.assetUrl({path: ""})` (`require('/lib/enonic/asset')`). The existing `/lib/xp/portal` import stays because the same files still use `portal.serviceUrl(...)`.

The `portal.assetUrl(...)` calls inside `rewrite-manager.html` are Thymeleaf view functions provided by `lib-thymeleaf` (Java-side, backed directly by `PortalUrlService.assetUrl`) and are not affected by the JS deprecation — out of scope here.

## Test plan

- [x] `./gradlew build --refresh-dependencies` is clean.
- [x] Inline `claude-dev` E2E (`/tmp/xp-e2e-…`): bundle reaches ACTIVE — `Started application com.enonic.app.rewrite bundle 117`, no ERROR/WARN related to the migration.
- [x] Admin tool page `GET /admin/com.enonic.app.rewrite/rewrite-manager` returns HTTP 200; rendered HTML emits the new asset URL pattern, e.g. `/admin/com.enonic.app.rewrite/rewrite-manager/_/asset/com.enonic.app.rewrite:<fingerprint>/css/main.css`.
- [x] Each generated asset URL is reachable with the expected content-type:
  - `/css/main.css` → 200 `text/css`
  - `/icons/favicon.svg` → 200 `image/svg+xml`
  - `/js/main.js` → 200 `application/javascript`
- [x] All three migrated render services return 200 under the admin-tool context (`/admin/com.enonic.app.rewrite/rewrite-manager/_/service/com.enonic.app.rewrite/{tool-context-render,tool-rules-render,tool-tester-render}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)