### PR TITLE
GraalJS Compatibility #1154

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:6.1.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation "com.enonic.xp:testing:${xpVersion}"
-    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 repositories {
@@ -54,17 +53,9 @@ test {
     useJUnitPlatform()
 }
 
-def testGraalJs = tasks.register('testGraalJs', Test) {
-    group = 'verification'
-    description = 'Runs tests with the GraalJS script engine.'
-    useJUnitPlatform()
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-    systemProperty 'xp.script-engine', 'GraalJS'
-    shouldRunAfter test
+xp {
+    scriptEngines = ['Nashorn', 'GraalJS']
 }
-
-check.dependsOn testGraalJs
 
 node {
     download = true

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:6.1.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation "com.enonic.xp:testing:${xpVersion}"
+    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 repositories {
@@ -52,6 +53,18 @@ check.dependsOn jacocoTestReport
 test {
     useJUnitPlatform()
 }
+
+def testGraalJs = tasks.register('testGraalJs', Test) {
+    group = 'verification'
+    description = 'Runs tests with the GraalJS script engine.'
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    systemProperty 'xp.script-engine', 'GraalJS'
+    shouldRunAfter test
+}
+
+check.dependsOn testGraalJs
 
 node {
     download = true

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ version = 2.1.0-SNAPSHOT
 
 # XP App values
 appName = com.enonic.app.rewrite
-xpVersion = 8.0.2
+xpVersion = 8.1.0-SNAPSHOT
 
 # Settings for publishing to a Maven repo
 group = com.enonic.app

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.enonic.xp.settings' version '4.1.0'
+    id 'com.enonic.xp.settings' version '4.2.0'
 }
 
 rootProject.name = projectName

--- a/src/main/resources/lib/rewrite-dao.js
+++ b/src/main/resources/lib/rewrite-dao.js
@@ -53,13 +53,13 @@ exports.reloadRewriteMappings = function () {
 
 exports.createRule = function (host, contextKey, rule, insertStrategy, position) {
     let params = __.newBean('com.enonic.app.rewrite.UpdateRuleParams');
-    params.host = host;
-    params.insertStrategy = insertStrategy;
-    params.source = rule.source;
-    params.target = rule.target;
-    params.type = rule.type;
-    params.contextKey = contextKey;
-    params.position = position;
+    params.setHost(__.nullOrValue(host));
+    params.setInsertStrategy(__.nullOrValue(insertStrategy));
+    params.setSource(__.nullOrValue(rule.source));
+    params.setTarget(__.nullOrValue(rule.target));
+    params.setType(__.nullOrValue(rule.type));
+    params.setContextKey(__.nullOrValue(contextKey));
+    params.setPosition(position);
 
     let result = bean.saveRule(params);
     return __.toNativeObject(result);
@@ -67,21 +67,21 @@ exports.createRule = function (host, contextKey, rule, insertStrategy, position)
 
 exports.deleteRule = function (contextKey, ruleId) {
     let params = __.newBean('com.enonic.app.rewrite.DeleteRuleParams');
-    params.contextKey = contextKey;
-    params.ruleId = ruleId;
+    params.setContextKey(__.nullOrValue(contextKey));
+    params.setRuleId(__.nullOrValue(ruleId));
     let result = bean.deleteRule(params);
     return __.toNativeObject(result);
 };
 
 exports.editRule = function (host, contextKey, pattern, rule) {
     let params = __.newBean('com.enonic.app.rewrite.UpdateRuleParams');
-    params.host = host;
-    params.contextKey = contextKey;
-    params.source = rule.source;
-    params.target = rule.target;
-    params.type = rule.type;
-    params.position = rule.position;
-    params.ruleId = rule.ruleId;
+    params.setHost(__.nullOrValue(host));
+    params.setContextKey(__.nullOrValue(contextKey));
+    params.setSource(__.nullOrValue(rule.source));
+    params.setTarget(__.nullOrValue(rule.target));
+    params.setType(__.nullOrValue(rule.type));
+    params.setPosition(rule.position);
+    params.setRuleId(__.nullOrValue(rule.ruleId));
 
     let result = bean.saveRule(params);
     return __.toNativeObject(result);
@@ -90,13 +90,13 @@ exports.editRule = function (host, contextKey, pattern, rule) {
 
 exports.importRules = function (contextKey, mergeStrategy, byteSource, fileName, dryRun, format) {
     let params = __.newBean('com.enonic.app.rewrite.ImportRulesParams');
-    params.contextKey = contextKey;
-    params.mergeStrategy = mergeStrategy;
-    params.byteSource = byteSource;
-    params.fileName = fileName;
-    params.dryRun = dryRun;
+    params.setContextKey(__.nullOrValue(contextKey));
+    params.setMergeStrategy(__.nullOrValue(mergeStrategy));
+    params.setByteSource(byteSource);
+    params.setFileName(__.nullOrValue(fileName));
+    params.setDryRun(dryRun);
     if (format) {
-        params.format = format;
+        params.setFormat(format);
     }
     let result = bean.importRules(params);
     return __.toNativeObject(result);
@@ -104,8 +104,8 @@ exports.importRules = function (contextKey, mergeStrategy, byteSource, fileName,
 
 exports.serializeRules = function (contextKey, format) {
     let params = __.newBean('com.enonic.app.rewrite.ExportRulesParams');
-    params.contextKey = contextKey;
-    params.format = format;
+    params.setContextKey(__.nullOrValue(contextKey));
+    params.setFormat(format);
     let result = bean.serializeRules(params);
     return result;
 };
@@ -113,9 +113,9 @@ exports.serializeRules = function (contextKey, format) {
 exports.testRequest = function (params) {
     let testerParams = __.newBean('com.enonic.app.rewrite.RequestTesterParams');
 
-    testerParams.host = required(params, 'host');
-    testerParams.requestPath = required(params, 'requestPath');
-    testerParams.rewriteContext = required(params, 'rewriteContext');
+    testerParams.setHost(required(params, 'host'));
+    testerParams.setRequestPath(required(params, 'requestPath'));
+    testerParams.setRewriteContext(required(params, 'rewriteContext'));
 
     return __.toNativeObject(bean.requestTester(testerParams));
 };

--- a/src/test/java/com/enonic/app/rewrite/RewriteDaoScriptTest.java
+++ b/src/test/java/com/enonic/app/rewrite/RewriteDaoScriptTest.java
@@ -1,0 +1,185 @@
+package com.enonic.app.rewrite;
+
+import com.enonic.app.rewrite.domain.RewriteContextKey;
+import com.enonic.app.rewrite.format.SourceFormat;
+import com.enonic.app.rewrite.ie.ImportResult;
+import com.enonic.app.rewrite.ie.ImportService;
+import com.enonic.app.rewrite.requesttester.RequestTester;
+import com.enonic.app.rewrite.requesttester.RequestTesterResult;
+import com.enonic.xp.testing.ScriptRunnerSupport;
+import com.enonic.xp.web.vhost.VirtualHostService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RewriteDaoScriptTest
+    extends ScriptRunnerSupport
+{
+    private UpdateRuleParams savedRule;
+
+    private DeleteRuleParams deletedRule;
+
+    private ImportRulesParams importedRules;
+
+    private ExportRulesParams exportedRules;
+
+    private RequestTesterParams testedRequest;
+
+    @Override
+    protected void initialize()
+        throws Exception
+    {
+        super.initialize();
+
+        final RewriteService rewriteService = mock( RewriteService.class );
+        final RequestTester requestTester = mock( RequestTester.class );
+        final ImportService importService = mock( ImportService.class );
+        final VirtualHostService virtualHostService = mock( VirtualHostService.class );
+
+        when( requestTester.hasLoops( any() ) ).thenReturn( false );
+
+        doAnswer( invocation -> {
+            this.savedRule = invocation.getArgument( 0 );
+            return null;
+        } ).when( rewriteService ).saveRule( any() );
+
+        doAnswer( invocation -> {
+            this.deletedRule = invocation.getArgument( 0 );
+            return null;
+        } ).when( rewriteService ).deleteRule( any() );
+
+        when( importService.importRules( any() ) ).thenAnswer( invocation -> {
+            this.importedRules = invocation.getArgument( 0 );
+            return ImportResult.create().build();
+        } );
+
+        when( importService.serializeRules( any() ) ).thenAnswer( invocation -> {
+            this.exportedRules = invocation.getArgument( 0 );
+            return "SERIALIZED_RULES";
+        } );
+
+        when( requestTester.testRequest( any() ) ).thenAnswer( invocation -> {
+            this.testedRequest = invocation.getArgument( 0 );
+            return RequestTesterResult.create().build();
+        } );
+
+        addService( RewriteService.class, rewriteService );
+        addService( RequestTester.class, requestTester );
+        addService( ImportService.class, importService );
+        addService( VirtualHostService.class, virtualHostService );
+    }
+
+    @Override
+    public String getScriptTestFile()
+    {
+        return "/lib/rewrite-dao-test.js";
+    }
+
+    public String getSavedHost()
+    {
+        return this.savedRule.getHost();
+    }
+
+    public String getSavedInsertStrategy()
+    {
+        return this.savedRule.getInsertStrategy();
+    }
+
+    public String getSavedSource()
+    {
+        return this.savedRule.getSource();
+    }
+
+    public String getSavedTarget()
+    {
+        return this.savedRule.getTarget();
+    }
+
+    public String getSavedType()
+    {
+        return this.savedRule.getType();
+    }
+
+    public String getSavedContextKey()
+    {
+        return asString( this.savedRule.getContextKey() );
+    }
+
+    public Integer getSavedPosition()
+    {
+        return this.savedRule.getPosition();
+    }
+
+    public String getSavedRuleId()
+    {
+        return this.savedRule.getRuleId();
+    }
+
+    public String getDeletedContextKey()
+    {
+        return asString( this.deletedRule.getContextKey() );
+    }
+
+    public String getDeletedRuleId()
+    {
+        return this.deletedRule.getRuleId();
+    }
+
+    public String getImportedContextKey()
+    {
+        return asString( this.importedRules.getContextKey() );
+    }
+
+    public String getImportedMergeStrategy()
+    {
+        return this.importedRules.getMergeStrategy();
+    }
+
+    public String getImportedFileName()
+    {
+        return this.importedRules.getFileName();
+    }
+
+    public boolean getImportedDryRun()
+    {
+        return this.importedRules.isDryRun();
+    }
+
+    public String getImportedFormat()
+    {
+        return this.importedRules.getFormat();
+    }
+
+    public String getExportedContextKey()
+    {
+        return asString( this.exportedRules.getContextKey() );
+    }
+
+    public String getExportedFormat()
+    {
+        final SourceFormat format = this.exportedRules.getFormat();
+        return format == null ? null : format.name();
+    }
+
+    public String getTestedHost()
+    {
+        return this.testedRequest.getHost();
+    }
+
+    public String getTestedRequestPath()
+    {
+        return this.testedRequest.getRequestPath();
+    }
+
+    public String getTestedRewriteContext()
+    {
+        return this.testedRequest.getRewriteContext();
+    }
+
+    private static String asString( final RewriteContextKey contextKey )
+    {
+        return contextKey == null ? null : contextKey.toString();
+    }
+}

--- a/src/test/resources/lib/rewrite-dao-test.js
+++ b/src/test/resources/lib/rewrite-dao-test.js
@@ -1,0 +1,85 @@
+var rewriteDao = require('/lib/rewrite-dao');
+var assert = require('/lib/xp/testing');
+
+exports.testCreateRule = function () {
+    var rule = {
+        source: '/old',
+        target: '/new',
+        type: 'permanent'
+    };
+
+    var result = rewriteDao.createRule('create.example.com', 'createvhost', rule, 'BOTTOM', 3);
+
+    assert.assertNull(result);
+    assert.assertEquals('create.example.com', testInstance.getSavedHost());
+    assert.assertEquals('BOTTOM', testInstance.getSavedInsertStrategy());
+    assert.assertEquals('/old', testInstance.getSavedSource());
+    assert.assertEquals('/new', testInstance.getSavedTarget());
+    assert.assertEquals('permanent', testInstance.getSavedType());
+    assert.assertEquals('createvhost', testInstance.getSavedContextKey());
+    assert.assertEquals(3, testInstance.getSavedPosition());
+};
+
+exports.testEditRule = function () {
+    var rule = {
+        source: '/from',
+        target: '/to',
+        type: 'forward',
+        position: 5,
+        ruleId: 'rule-123'
+    };
+
+    var result = rewriteDao.editRule('edit.example.com', 'editvhost', '/pattern', rule);
+
+    assert.assertNull(result);
+    assert.assertEquals('edit.example.com', testInstance.getSavedHost());
+    assert.assertEquals('editvhost', testInstance.getSavedContextKey());
+    assert.assertEquals('/from', testInstance.getSavedSource());
+    assert.assertEquals('/to', testInstance.getSavedTarget());
+    assert.assertEquals('forward', testInstance.getSavedType());
+    assert.assertEquals(5, testInstance.getSavedPosition());
+    assert.assertEquals('rule-123', testInstance.getSavedRuleId());
+};
+
+exports.testDeleteRule = function () {
+    var result = rewriteDao.deleteRule('deletevhost', 'rule-999');
+
+    assert.assertNull(result);
+    assert.assertEquals('deletevhost', testInstance.getDeletedContextKey());
+    assert.assertEquals('rule-999', testInstance.getDeletedRuleId());
+};
+
+exports.testImportRules = function () {
+    var result = rewriteDao.importRules('importvhost', 'overwrite', null, 'rules.csv', true, 'csv');
+
+    assert.assertNotNull(result);
+    assert.assertEquals('importvhost', testInstance.getImportedContextKey());
+    assert.assertEquals('overwrite', testInstance.getImportedMergeStrategy());
+    assert.assertEquals('rules.csv', testInstance.getImportedFileName());
+    assert.assertEquals(true, testInstance.getImportedDryRun());
+    assert.assertEquals('csv', testInstance.getImportedFormat());
+};
+
+exports.testSerializeRules = function () {
+    var result = rewriteDao.serializeRules('exportvhost', 'csv');
+
+    assert.assertEquals('SERIALIZED_RULES', result);
+    assert.assertEquals('exportvhost', testInstance.getExportedContextKey());
+    assert.assertEquals('CSV', testInstance.getExportedFormat());
+};
+
+exports.testTestRequest = function () {
+    var params = {
+        host: 'tester.example.com',
+        requestPath: '/some/path',
+        rewriteContext: 'testervhost'
+    };
+
+    var result = rewriteDao.testRequest(params);
+
+    assert.assertNotNull(result);
+    assert.assertEquals('OK', result.state);
+    assert.assertEquals('tester.example.com', testInstance.getTestedHost());
+    assert.assertEquals('/some/path', testInstance.getTestedRequestPath());
+    assert.assertEquals('testervhost', testInstance.getTestedRewriteContext());
+};


### PR DESCRIPTION
Fixes #1154

## What

Nashorn maps a property write on a Java host object to its setter (`bean.foo = x` → `setFoo(x)`). GraalJS does not — the shorthand went away with nashorn-compat mode (enonic/xp#9236) — so each such write now throws at runtime:

```
TypeError: writeMember (host) on com.enonic.app.rewrite.UpdateRuleParams failed due to: Unknown identifier: host
```

All **27** affected writes in `src/main/resources/lib/rewrite-dao.js` now call the setter instead, across `UpdateRuleParams`, `DeleteRuleParams`, `ImportRulesParams`, `ExportRulesParams` and `RequestTesterParams`. Setter names were confirmed against each Java class. Optional `String` values that are read straight off the incoming params (and may be `undefined`) are wrapped in `__.nullOrValue(...)` so they reach the `String` setter as `null` rather than `undefined` — the property form used to hide that. `required(...)`-guaranteed values, the `if (format)`-guarded write, and the non-`String` setters (`setPosition(Integer)`, `setDryRun(boolean)`, `setByteSource(ByteSource)`) are not wrapped.

Same fix as enonic/lib-sql#154.

## Test on both engines

The repository had **no JS-executing tests**, so nothing reached these sites on either engine. This PR adds one:

- `src/test/resources/lib/rewrite-dao-test.js` — exercises every affected export (`createRule`, `editRule`, `deleteRule`, `importRules`, `serializeRules`, `testRequest`) and asserts the values propagate to the Java beans (mocked services capture the params; the JS reads them back through `testInstance`).
- `src/test/java/com/enonic/app/rewrite/RewriteDaoScriptTest.java` — a `ScriptRunnerSupport` harness that runs those specs.

The specs run once per engine — Nashorn via `test`, GraalJS via a new `testGraalJs` task wired into `check` (mirrors `gradle/js-tests.gradle` in the platform). This required bumping `xpVersion` to `8.1.0-SNAPSHOT` and adding `xp.enonicRepo('dev')` (already present).

## Verified locally

Built the platform branch (`publishToMavenLocal`, GraalVM CE 25) and ran both tasks against it:

```
test         RewriteDaoScriptTest  6 tests, 0 failed   (Nashorn)
testGraalJs  RewriteDaoScriptTest  6 tests, 0 failed   (GraalJS)
```

As a negative control, reintroducing a single property write (`params.host = host;`) makes `testGraalJs` fail 1/6 on `testCreateRule` with exactly the `TypeError: writeMember (host) ... Unknown identifier: host` above, while Nashorn `test` stays green — the divergence the second engine exists to catch.

## ⚠️ CI `testGraalJs` stays red until enonic/xp#12198 is published

`testGraalJs` needs the `ScriptRunnerSupport` fix from **enonic/xp#12198** ("keep the script executor alive through JS test discovery"); the old `ScriptRunnerSupport` closes the script executor during test discovery, so every GraalJS spec fails with `IllegalStateException: The Context is already closed` regardless of this app's code. The `8.1.0-SNAPSHOT` currently on `repo.enonic.com/dev` still carries the old version.

**This is why the PR is a draft.** CI `testGraalJs` will stay red until enonic/xp#12198 is merged and a fresh `8.1.0-SNAPSHOT` is published; the setter fix itself is verified green above against a local build of that branch. Nashorn `test` is unaffected and green.
